### PR TITLE
switching to use SSL by default

### DIFF
--- a/hapi/__init__.py
+++ b/hapi/__init__.py
@@ -70,7 +70,7 @@ class Client:
     __xmlout = False
     __headers = None
 
-    def __init__(self, key=None, secret=None, ssl=False):
+    def __init__(self, key=None, secret=None, ssl=True):
         self.methodparts = []
         self.key = key
         self.secret = secret


### PR DESCRIPTION
it is very insecure to use http and not https by default since the ssh console details return when using http